### PR TITLE
Use LongText for COLUMN_CONTENTS in database schema

### DIFF
--- a/store.go
+++ b/store.go
@@ -34,7 +34,7 @@ func (store *Store) MigrateUp(ctx context.Context, tx ...*sql.Tx) error {
 		table.String(COLUMN_PARENT_ID, 40)
 		table.String(COLUMN_TYPE, 10)
 		table.String(COLUMN_NAME, 100)
-		table.Text(COLUMN_CONTENTS)
+		table.LongText(COLUMN_CONTENTS)
 		table.String(COLUMN_SIZE, 20)
 		table.String(COLUMN_EXTENSION, 12)
 		table.String(COLUMN_PATH, 2048)


### PR DESCRIPTION
I have updated the database schema migration to use `table.LongText` for the `COLUMN_CONTENTS` field in `store.go`. This change ensures that the file contents can accommodate long text data, as requested.

Key changes:
- Updated `store.go`'s `MigrateUp` method to use `table.LongText(COLUMN_CONTENTS)` instead of `table.Text(COLUMN_CONTENTS)`.
- Verified the change by running existing tests, which all passed successfully.

---
*PR created automatically by Jules for task [14629040175292616293](https://jules.google.com/task/14629040175292616293) started by @lesichkovm*